### PR TITLE
fix: clone req when putting it into the cache

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -51,7 +51,9 @@ export class Cache {
   }
 
   async put(request: RequestInfo, response: Response): Promise<void> {
-    const req = request instanceof Request ? request : new Request(request);
+    const req = request instanceof Request
+      ? request.clone()
+      : new Request(request);
 
     const status = response.status;
     const headers = Object.fromEntries(response.headers.entries());


### PR DESCRIPTION
See https://w3c.github.io/ServiceWorker/#cache-put step 9.﻿
