### PR TITLE
Create an S3 cache implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,19 @@ jobs:
           --health-retries 5
         ports:
           - 6379:6379
+      minio:
+        image: minio/minio
+        command: server /data # GHA will not accept this
+        env:
+          MINIO_ACCESS_KEY: AKIAIOSFODNN7EXAMPLE
+          MINIO_SECRET_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+        options: >-
+          --health-cmd "/usr/bin/healthcheck.sh"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 9000:9000
 
     steps:
       - name: Setup repo

--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ const cache = await redisCache("redis://127.0.0.1:6379");
 const cache = await redisCache("redis://127.0.0.1:6379", "v1-");
 ```
 
+With Amazon S3 for long-term caching:
+
+```ts
+import { s3Cache } from "https://deno.land/x/httpcache@0.1.2/s3.ts";
+import { S3Bucket } from "https://deno.land/x/s3@0.4.0/mod.ts";
+
+const bucket = new S3Bucket({
+  accessKeyID: Deno.env.get("AWS_ACCESS_KEY_ID")!,
+  secretKey: Deno.env.get("AWS_SECRET_ACCESS_KEY")!,
+  region: Deno.env.get("AWS_REGION")!,
+  bucket: "my-bucket",
+});
+const cache = await s3Cache(bucket);
+
+// you can also optionally specify a prefix to use for the object keys:
+const cache = await s3Cache(bucket, "cache/");
+```
+
 ## Contributing
 
 Before submitting a PR, please run these three steps and check that they pass.

--- a/s3.ts
+++ b/s3.ts
@@ -2,36 +2,84 @@ import type { S3Bucket } from "https://deno.land/x/s3@0.4.0/src/bucket.ts";
 import { Cache } from "./mod.ts";
 export { Cache };
 
+/**
+ * A durable cache good for storing diverse immutable bodies
+ * for long periods of time.
+ *
+ * For most items the cache headers will be stored as S3 metadata.
+ * This means the response body can be accessed without manipulation.
+ * After the cache metadata for an item nears 2KiB,
+ * it needs to instead be stored within the S3 object's body;
+ * this shows up as a line of JSON text prepended to the payload
+ * followed by a newline byte "\n"
+ *
+ * @param s3 Preconfigured S3 bucket API from /x/s3
+ * @param prefix Optional prefix to be used for all S3 keys
+ */
+
 export function s3Cache(
   s3: S3Bucket,
   prefix = "",
 ): Cache {
-
   function urlKey(url: string) {
     return prefix + url.replace('://', '/') + '.cache';
   }
-
   return new Cache({
+
     async get(url) {
       const data = await s3.getObject(urlKey(url));
       if (!data) return undefined;
+
+      if (data.meta['cache-policy'] === 'inline') {
+        const body = new Uint8Array(await new Response(data.body).arrayBuffer());
+        const idx = body.indexOf(10);
+        return {
+          policy: JSON.parse(new TextDecoder().decode(body.slice(0, idx))),
+          body: body.slice(idx+1),
+        };
+      }
+
       return {
         policy: JSON.parse(data.meta['cache-policy'] || '{}'),
         body: new Uint8Array(await new Response(data.body).arrayBuffer()),
       };
     },
+
     async set(url, resp) {
-      const contentTypes = resp.policy.resh['content-type'] ?? [];
+      const list = resp.policy.resh['content-type'] ?? [];
+      const contentType = Array.isArray(list) ? list[0] : list;
+
+      const policy = JSON.stringify(resp.policy);
+      if (policy.length > 1800) {
+        const encodedPolicy = new TextEncoder().encode(policy);
+        const body = new Uint8Array(encodedPolicy.length + 1 + resp.body.length);
+        body.set(encodedPolicy, 0);
+        body.set([10], encodedPolicy.length);
+        body.set(resp.body, encodedPolicy.length + 1);
+
+        await s3.putObject(urlKey(url), body, {
+          contentType: contentType.startsWith('text/')
+            ? 'text/x-httpcache'
+            : 'binary/x-httpcache',
+          meta: {
+            ['cache-policy']: 'inline',
+          },
+        });
+        return;
+      }
+
       await s3.putObject(urlKey(url), resp.body, {
-        contentType: Array.isArray(contentTypes) ? contentTypes[0] : contentTypes,
+        contentType: contentType,
         meta: {
           ['cache-policy']: JSON.stringify(resp.policy),
         },
       });
     },
+
     async delete(url) {
       await s3.deleteObject(urlKey(url));
     },
+
     close() {},
   });
 }

--- a/s3.ts
+++ b/s3.ts
@@ -1,0 +1,37 @@
+import type { S3Bucket } from "https://deno.land/x/s3@0.4.0/src/bucket.ts";
+import { Cache } from "./mod.ts";
+export { Cache };
+
+export function s3Cache(
+  s3: S3Bucket,
+  prefix = "",
+): Cache {
+
+  function urlKey(url: string) {
+    return prefix + url.replace('://', '/') + '.cache';
+  }
+
+  return new Cache({
+    async get(url) {
+      const data = await s3.getObject(urlKey(url));
+      if (!data) return undefined;
+      return {
+        policy: JSON.parse(data.meta['cache-policy'] || '{}'),
+        body: new Uint8Array(await new Response(data.body).arrayBuffer()),
+      };
+    },
+    async set(url, resp) {
+      const contentTypes = resp.policy.resh['content-type'] ?? [];
+      await s3.putObject(urlKey(url), resp.body, {
+        contentType: Array.isArray(contentTypes) ? contentTypes[0] : contentTypes,
+        meta: {
+          ['cache-policy']: JSON.stringify(resp.policy),
+        },
+      });
+    },
+    async delete(url) {
+      await s3.deleteObject(urlKey(url));
+    },
+    close() {},
+  });
+}

--- a/s3_test.ts
+++ b/s3_test.ts
@@ -1,0 +1,64 @@
+import { S3Bucket } from "https://deno.land/x/s3@0.4.0/mod.ts";
+import { s3Cache } from "./s3.ts";
+import { assert, assertEquals } from "./test_deps.ts";
+
+const bucket = new S3Bucket({
+  accessKeyID: Deno.env.get("AWS_ACCESS_KEY_ID")!,
+  secretKey: Deno.env.get("AWS_SECRET_ACCESS_KEY")!,
+  sessionToken: Deno.env.get('AWS_SESSION_TOKEN'),
+  region: Deno.env.get("AWS_REGION") || "us-east-1",
+  bucket: Deno.env.get("S3_BUCKET") || "test",
+  endpointURL: Deno.env.get("S3_ENDPOINT_URL"),
+});
+
+Deno.test("[s3] cache, retrieve, delete", async () => {
+  const cache = s3Cache(bucket, "tests-");
+
+  const originalResp = new Response("Hello World", {
+    status: 200,
+    headers: {
+      "server": "deno",
+      "cache-control": "public, max-age=604800, immutable",
+    },
+  });
+
+  await cache.put("https://deno.land", originalResp);
+
+  const cachedResp = await cache.match("https://deno.land");
+  assert(cachedResp);
+  assertEquals(originalResp.status, cachedResp.status);
+  assertEquals(
+    originalResp.headers.get("server"),
+    cachedResp.headers.get("server"),
+  );
+  assertEquals(await originalResp.text(), await cachedResp.text());
+
+  await cache.delete("https://deno.land");
+
+  const otherCachedResp = await cache.match("https://deno.land");
+  assert(otherCachedResp === undefined);
+});
+
+// Ensures that document tiers can be stored without conflicting
+// Amazon S3 is fine with this overall; Minio is more problematic
+Deno.test("[s3] flexible path hierachy", async () => {
+  const cache = s3Cache(bucket, "tests-");
+
+  function buildResp(text: string) {
+    return new Response(text, {
+      status: 200,
+      headers: {
+        "server": "deno",
+        "cache-control": "public, max-age=604800, immutable",
+      },
+    });
+  }
+
+  await cache.put("https://deno.land/std/examples/welcome.ts", buildResp('Welcome'));
+  await cache.put("https://deno.land/std/examples/", buildResp('Examples'));
+  await cache.put("https://deno.land/std/", buildResp('std'));
+
+  const cachedResp = await cache.match("https://deno.land/std/examples/");
+  assert(cachedResp);
+  assertEquals(await 'Examples', await cachedResp.text());
+});


### PR DESCRIPTION
The code here is working pretty well for me on real S3, however it's a bit trickier to test with a minio instance. Apparently minio treats S3 as a filesystem so `https/deno.land/` (trailing slash) can only be a folder, and if `https/example.com/hello` exists, it's impossible to create `https/example.com` (no trailing slash). Real S3 is a key/value store so putting URLs directly into the keys has been fine.

To work around this I have a `urlKey` function that mangles `://` and suffixes the keys with `.cache`. I also wrote a test that caches a directory structure, and the files from that test look like this:

```
aws s3 ls --recursive s3://test/
2021-04-02 08:25:46          3 tests-https/deno.land/std/.cache
2021-04-02 08:25:46          8 tests-https/deno.land/std/examples/.cache
2021-04-02 08:25:46          7 tests-https/deno.land/std/examples/welcome.ts.cache
```

Also, I don't think Github Actions can really set up `minio/minio` as a service. It seems that extra scripts and/or a custom image is necesary. You probably already knew that from testing `/x/s3` but I wasn't sure what way to go so the CI is currently broken in this PR.

Outside of Minio, the actual footnote that I have is that S3 metadata is limited to 2KiB and that's where I put the cache policy. This works well for me (github response headers are ~1KiB) but I can see this being a cryptic error message & I think a reasonable workaround would be detecting large cache policies on write and storing them into the object as a fallback.

## Remaining work

* [ ] CI strategy
* [x] Large cachepolicy/headers support